### PR TITLE
Feat#02 vercel

### DIFF
--- a/.github/workflows/deploy-to-fork.yml
+++ b/.github/workflows/deploy-to-fork.yml
@@ -1,0 +1,30 @@
+name: git push into Fork Repo
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'output'
+          destination-github-username: Dobbymin
+          destination-repository-name: ClipFE-v2
+          user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      
+      - name: creates output
+        run: sh ./build.sh
+      
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'output'
+          destination-github-username: Dobbymin
+          destination-repository-name: ClipFE-v2
+          user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./ClipFE-v2/* ./output
+cp -R ./output ./ClipFE-v2/


### PR DESCRIPTION
### 📝 요약 (Summary)

Vercel 배포 자동화를 위해 **GitHub Actions** 워크플로우를 구축했습니다. Organization 레포지토리(`main` 브랜치)에 코드가 푸시되면, Vercel 배포의 기반이 되는 개인 Fork 레포지토리로 변경 사항이 **자동으로 미러링**되도록 설정하여 수동 동기화의 번거로움을 해결했습니다.

### ✅ 주요 변경 사항 (Key Changes)

- `main` 브랜치 푸시 시 Fork 레포지토리로 자동 동기화를 수행하는 GitHub Actions 워크플로우 (`deploy.yml`) 추가
- 배포할 소스 코드를 준비하는 `build.sh` 스크립트 작성

### 💻 상세 구현 내용 (Implementation Details)

### 1. Vercel 배포 제약사항 해결을 위한 아키텍처를 설계한 이유

**문제점**: Vercel의 현재 요금 정책상, Organization에 속한 레포지토리를 배포하려면 유료 플랜이 필요합니다. 무료 플랜을 활용하여 지속적인 배포 환경을 구축하기 위해, **Organization 레포지토리를 개인 계정으로 Fork**하고, 이 Fork된 레포지토리를 Vercel에 연결하는 아키텍처를 채택했습니다. 하지만 이 구조는 원본 레포지토리의 변경 사항을 Fork된 레포지토리에 수동으로 동기화해야 하는 번거로움이 있었습니다.

**해결**: 이러한 수동 작업을 자동화하기 위해 **GitHub Actions**를 도입했습니다.

- **동작 방식**: 원본 레포지토리의 `main` 브랜치에 `push` 이벤트가 발생할 때마다 워크플로우가 실행됩니다. `cpina/github-action-push-to-another-repository` 액션을 사용하여, 원본 레포지토리의 최신 코드를 Fork 레포지토리의 `main` 브랜치로 푸시하도록 설정했습니다.

### 🚀 트러블 슈팅 (Trouble Shooting)

초기 설정 시, 원본 레포지토리의 커밋 히스토리가 아닌, 액션 자체의 커밋 메시지로 Fork 레포에 푸시되는 문제가 있었습니다. 이를 해결하기 위해 `commit-message` 옵션에 `${{ github.event.commits[0].message }}`를 사용하여, **원본 커밋 메시지를 그대로 동기화**하도록 수정하여 히스토리 추적의 용이성을 확보했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

이번 작업에서는 알려진 이슈 및 참고 사항이 없습니다.

## 📸 스크린샷 (Screenshots)
x

## #️⃣ 관련 이슈 (Related Issues)

- Close #2